### PR TITLE
Fix mgmt API server configuration

### DIFF
--- a/src/mgmtApi/api/api.go
+++ b/src/mgmtApi/api/api.go
@@ -13,17 +13,17 @@ func Init() {
 	// Load configuration
 	c := config.GetConfig()
 
-	// DNS API for PowerDNS (unchanged)
-	dnsApi := http.NewServeMux()
-	dnsApi.HandleFunc("/dns", router)
+	// Management API
+	mgmtMux := http.NewServeMux()
+	mgmtMux.HandleFunc("/api", router)
 
-	log.Log(log.Info, "Starting DNS API server on %s:%s",
-		c.Local.DnsApi.ListenAddress,
-		c.Local.DnsApi.ListenPort,
+	log.Log(log.Info, "Starting Mgmt API server on %s:%s",
+		c.Local.MgmtApi.ListenAddress,
+		c.Local.MgmtApi.ListenPort,
 	)
 
 	go http.ListenAndServe(
-		c.Local.DnsApi.ListenAddress+":"+c.Local.DnsApi.ListenPort,
-		dnsApi,
+		c.Local.MgmtApi.ListenAddress+":"+c.Local.MgmtApi.ListenPort,
+		mgmtMux,
 	)
 }

--- a/src/mgmtApi/api/router.go
+++ b/src/mgmtApi/api/router.go
@@ -20,13 +20,13 @@ func router(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch req.Method {
-	case "initialize":
+	case "billing":
 		res = handlers.ApiQuery_Billing(w, r, req)
-	case "lookup":
+	case "member":
 		res = handlers.ApiQuery_Member(w, r, req)
-	case "list":
+	case "status":
 		res = handlers.ApiQuery_Status(w, r, req)
-	case "getDomainInfo":
+	case "usage":
 		res = handlers.ApiQuery_Usage(w, r, req)
 	default:
 		writeDnsResponse(w, types.Response{Result: "Invalid Request"})

--- a/src/mgmtApi/mgmtApi.go
+++ b/src/mgmtApi/mgmtApi.go
@@ -10,7 +10,7 @@ import (
 	log "ibp-geodns/src/common/logging"
 	max "ibp-geodns/src/common/maxmind"
 	nats "ibp-geodns/src/common/nats"
-	api "ibp-geodns/src/dnsApi/api"
+	api "ibp-geodns/src/mgmtApi/api"
 )
 
 var version = "0.2.0"


### PR DESCRIPTION
## Summary
- fix wrong import for mgmt API main
- run mgmt API server with mgmt config and /api route
- correct router method names for mgmt API

## Testing
- `go vet ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*