### PR TITLE
Implement daily usage processing

### DIFF
--- a/src/common/data/data.go
+++ b/src/common/data/data.go
@@ -11,6 +11,7 @@ func Init() {
 	LoadAllCaches()
 	go startAutoUpdate()
 	go mysql.Init()
+	go startDailyUsageProcessor()
 }
 
 // MemberEnable sets the Override to 1 for the specified member name, stores it in MySQL, and triggers an event.

--- a/src/common/data/events.go
+++ b/src/common/data/events.go
@@ -79,3 +79,8 @@ func RecordEvent(checkType, checkName, memberName, domainName, endpoint string, 
 		}
 	}
 }
+
+// GetDowntimeEvents returns events for a member within the given time range.
+func GetDowntimeEvents(memberName string, start, end time.Time) ([]mysql.EventRecord, error) {
+	return mysql.GetEvents(memberName, start, end)
+}

--- a/src/common/data/mysql/events.go
+++ b/src/common/data/mysql/events.go
@@ -85,3 +85,28 @@ func FindOpenOfflineEvent(memberName, checkType, checkName, domainName, endpoint
 	}
 	return &event, nil
 }
+
+// GetEvents retrieves events for a member within the specified time range.
+func GetEvents(memberName string, start, end time.Time) ([]EventRecord, error) {
+	query := `
+               SELECT id, member_name, check_type, check_name, domain_name, endpoint, status, start_time, end_time, error_text, additional_data
+               FROM member_events
+               WHERE member_name = ? AND start_time >= ? AND start_time <= ?
+       `
+	rows, err := DB.Query(query, memberName, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query events: %w", err)
+	}
+	defer rows.Close()
+
+	var res []EventRecord
+	for rows.Next() {
+		var ev EventRecord
+		if err := rows.Scan(&ev.ID, &ev.MemberName, &ev.CheckType, &ev.CheckName, &ev.DomainName, &ev.Endpoint,
+			&ev.Status, &ev.StartTime, &ev.EndTime, &ev.ErrorText, &ev.AdditionalData); err != nil {
+			return nil, fmt.Errorf("scan error: %w", err)
+		}
+		res = append(res, ev)
+	}
+	return res, nil
+}

--- a/src/common/data/mysql/usage.go
+++ b/src/common/data/mysql/usage.go
@@ -1,0 +1,107 @@
+package mysql
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+type UsageRecord struct {
+	Date        string
+	Domain      string
+	MemberName  sql.NullString
+	CountryCode string
+	Hits        int
+}
+
+// UpsertUsageRecord inserts or updates a usage record.
+func UpsertUsageRecord(rec UsageRecord) error {
+	query := `
+        INSERT INTO usage_daily
+            (usage_date, domain, member_name, country_code, hits)
+        VALUES (?, ?, ?, ?, ?)
+        ON DUPLICATE KEY UPDATE hits = hits + VALUES(hits)
+    `
+	_, err := DB.Exec(query, rec.Date, rec.Domain, rec.MemberName, rec.CountryCode, rec.Hits)
+	if err != nil {
+		return fmt.Errorf("failed to upsert usage record: %w", err)
+	}
+	return nil
+}
+
+// GetUsageByDomain returns aggregated usage grouped by country for a domain.
+func GetUsageByDomain(domain, startDate, endDate string) ([]UsageRecord, error) {
+	query := `
+        SELECT usage_date, domain, country_code, SUM(hits) as hits
+        FROM usage_daily
+        WHERE domain = ? AND usage_date BETWEEN ? AND ?
+        GROUP BY usage_date, domain, country_code
+        ORDER BY usage_date
+    `
+	rows, err := DB.Query(query, domain, startDate, endDate)
+	if err != nil {
+		return nil, fmt.Errorf("query error: %w", err)
+	}
+	defer rows.Close()
+
+	var res []UsageRecord
+	for rows.Next() {
+		var r UsageRecord
+		if err := rows.Scan(&r.Date, &r.Domain, &r.CountryCode, &r.Hits); err != nil {
+			return nil, fmt.Errorf("scan error: %w", err)
+		}
+		res = append(res, r)
+	}
+	return res, nil
+}
+
+// GetUsageByMember returns usage grouped by country for a domain/member.
+func GetUsageByMember(domain, member, startDate, endDate string) ([]UsageRecord, error) {
+	query := `
+        SELECT usage_date, domain, member_name, country_code, SUM(hits) as hits
+        FROM usage_daily
+        WHERE domain = ? AND member_name = ? AND usage_date BETWEEN ? AND ?
+        GROUP BY usage_date, domain, member_name, country_code
+        ORDER BY usage_date
+    `
+	rows, err := DB.Query(query, domain, member, startDate, endDate)
+	if err != nil {
+		return nil, fmt.Errorf("query error: %w", err)
+	}
+	defer rows.Close()
+
+	var res []UsageRecord
+	for rows.Next() {
+		var r UsageRecord
+		if err := rows.Scan(&r.Date, &r.Domain, &r.MemberName, &r.CountryCode, &r.Hits); err != nil {
+			return nil, fmt.Errorf("scan error: %w", err)
+		}
+		res = append(res, r)
+	}
+	return res, nil
+}
+
+// GetUsageByCountry returns overall usage grouped by country.
+func GetUsageByCountry(startDate, endDate string) ([]UsageRecord, error) {
+	query := `
+        SELECT usage_date, country_code, SUM(hits) as hits
+        FROM usage_daily
+        WHERE usage_date BETWEEN ? AND ?
+        GROUP BY usage_date, country_code
+        ORDER BY usage_date
+    `
+	rows, err := DB.Query(query, startDate, endDate)
+	if err != nil {
+		return nil, fmt.Errorf("query error: %w", err)
+	}
+	defer rows.Close()
+
+	var res []UsageRecord
+	for rows.Next() {
+		var r UsageRecord
+		if err := rows.Scan(&r.Date, &r.CountryCode, &r.Hits); err != nil {
+			return nil, fmt.Errorf("scan error: %w", err)
+		}
+		res = append(res, r)
+	}
+	return res, nil
+}

--- a/src/common/data/usage.go
+++ b/src/common/data/usage.go
@@ -1,0 +1,65 @@
+package data
+
+import (
+	"database/sql"
+	"time"
+
+	"ibp-geodns/src/common/data/mysql"
+)
+
+// UpsertUsage writes a usage record via the mysql package.
+func UpsertUsage(date string, domain string, member sql.NullString, country string, hits int) error {
+	rec := mysql.UsageRecord{
+		Date:        date,
+		Domain:      domain,
+		MemberName:  member,
+		CountryCode: country,
+		Hits:        hits,
+	}
+	return mysql.UpsertUsageRecord(rec)
+}
+
+func GetUsageByDomain(domain string, start, end time.Time) ([]mysql.UsageRecord, error) {
+	return mysql.GetUsageByDomain(domain, start.Format("2006-01-02"), end.Format("2006-01-02"))
+}
+
+func GetUsageByMember(domain, member string, start, end time.Time) ([]mysql.UsageRecord, error) {
+	return mysql.GetUsageByMember(domain, member, start.Format("2006-01-02"), end.Format("2006-01-02"))
+}
+
+func GetUsageByCountry(start, end time.Time) ([]mysql.UsageRecord, error) {
+	return mysql.GetUsageByCountry(start.Format("2006-01-02"), end.Format("2006-01-02"))
+}
+
+// ProcessDailyUsage processes stats for the given date and stores them in MySQL.
+func ProcessDailyUsage(date string) {
+	Stats.Mu.Lock()
+	dayStats, exists := Stats.Data[date]
+	Stats.Mu.Unlock()
+	if !exists {
+		return
+	}
+
+	for domain, ds := range dayStats {
+		for country, hits := range ds.ClientStats.Countries {
+			UpsertUsage(date, domain, sql.NullString{}, country, hits)
+		}
+		for memberName, ms := range ds.MemberStats {
+			for country, hits := range ms.Countries {
+				UpsertUsage(date, domain, sql.NullString{String: memberName, Valid: true}, country, hits)
+			}
+		}
+	}
+}
+
+func startDailyUsageProcessor() {
+	go func() {
+		for {
+			now := time.Now().UTC()
+			next := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 5, 0, 0, time.UTC)
+			time.Sleep(time.Until(next))
+			y := now.AddDate(0, 0, -1).Format("2006-01-02")
+			ProcessDailyUsage(y)
+		}
+	}()
+}


### PR DESCRIPTION
## Summary
- add automatic daily stats processing
- store usage information in a new MySQL table via helper functions
- expose downtimes retrieval helper

## Testing
- `GOTOOLCHAIN=local go build ./...` *(fails: go.mod requires go >= 1.24.2)*