### PR TITLE
Add daily usage tracking

### DIFF
--- a/src/common/data/data.go
+++ b/src/common/data/data.go
@@ -4,6 +4,7 @@ import (
 	cfg "ibp-geodns/src/common/config"
 	"ibp-geodns/src/common/data/mysql"
 	log "ibp-geodns/src/common/logging"
+	"time"
 )
 
 func Init() {
@@ -11,6 +12,12 @@ func Init() {
 	LoadAllCaches()
 	go startAutoUpdate()
 	go mysql.Init()
+	go func() {
+		for {
+			ProcessDailyStats()
+			time.Sleep(24 * time.Hour)
+		}
+	}()
 }
 
 // MemberEnable sets the Override to 1 for the specified member name, stores it in MySQL, and triggers an event.

--- a/src/common/data/mysql/usage.go
+++ b/src/common/data/mysql/usage.go
@@ -1,0 +1,119 @@
+package mysql
+
+import (
+	"fmt"
+	"time"
+)
+
+// UsageRecord represents a row in the daily_usage table.
+type UsageRecord struct {
+	Date    time.Time
+	Domain  string
+	ASN     string
+	Subnet  string
+	Country string
+	Hits    int
+}
+
+// InsertOrUpdateUsage inserts a new usage record or increments hits if it already exists.
+func InsertOrUpdateUsage(record UsageRecord) error {
+	query := `
+                INSERT INTO daily_usage (date, domain, asn, subnet, country, hits)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON DUPLICATE KEY UPDATE hits = hits + VALUES(hits)
+        `
+
+	_, err := DB.Exec(query, record.Date, record.Domain, record.ASN, record.Subnet, record.Country, record.Hits)
+	if err != nil {
+		return fmt.Errorf("failed to insert/update usage: %w", err)
+	}
+
+	return nil
+}
+
+// QueryUsageByDomain returns aggregated hits grouped by domain for the range.
+func QueryUsageByDomain(start, end time.Time) (map[string]int, error) {
+	query := `
+                SELECT domain, SUM(hits) as total
+                FROM daily_usage
+                WHERE date >= ? AND date <= ?
+                GROUP BY domain
+        `
+
+	rows, err := DB.Query(query, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("query by domain failed: %w", err)
+	}
+	defer rows.Close()
+
+	results := make(map[string]int)
+	for rows.Next() {
+		var domain string
+		var total int
+		if err := rows.Scan(&domain, &total); err != nil {
+			return nil, fmt.Errorf("scan domain usage: %w", err)
+		}
+		results[domain] = total
+	}
+
+	return results, nil
+}
+
+// QueryUsageByMember aggregates hits by member for the range. The member is
+// looked up based on the domain column using a configured mapping in the
+// database.
+func QueryUsageByMember(start, end time.Time) (map[string]int, error) {
+	query := `
+                SELECT m.member_name, SUM(u.hits) as total
+                FROM daily_usage u
+                JOIN domains m ON u.domain = m.domain
+                WHERE u.date >= ? AND u.date <= ?
+                GROUP BY m.member_name
+        `
+
+	rows, err := DB.Query(query, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("query by member failed: %w", err)
+	}
+	defer rows.Close()
+
+	results := make(map[string]int)
+	for rows.Next() {
+		var member string
+		var total int
+		if err := rows.Scan(&member, &total); err != nil {
+			return nil, fmt.Errorf("scan member usage: %w", err)
+		}
+		results[member] = total
+	}
+
+	return results, nil
+}
+
+// QueryUsageByCountry aggregates hits by country for the range.
+func QueryUsageByCountry(start, end time.Time) (map[string]int, error) {
+	query := `
+                SELECT country, SUM(hits) as total
+                FROM daily_usage
+                WHERE date >= ? AND date <= ?
+                GROUP BY country
+        `
+
+	rows, err := DB.Query(query, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("query by country failed: %w", err)
+	}
+	defer rows.Close()
+
+	results := make(map[string]int)
+	for rows.Next() {
+		var country string
+		var total int
+		if err := rows.Scan(&country, &total); err != nil {
+			return nil, fmt.Errorf("scan country usage: %w", err)
+		}
+		results[country] = total
+	}
+
+	return results, nil
+}

--- a/src/common/data/stats.go
+++ b/src/common/data/stats.go
@@ -4,6 +4,8 @@ import (
 	log "ibp-geodns/src/common/logging"
 	max "ibp-geodns/src/common/maxmind"
 	"time"
+
+	"ibp-geodns/src/common/data/mysql"
 )
 
 var (
@@ -154,4 +156,47 @@ func MemberHit(memberName string, ReqIP string, ReqDomain string) {
 	memberStats.Requests++
 	memberStats.ClassCs[classC]++
 	memberStats.Countries[countryCode]++
+}
+
+// ProcessDailyStats moves statistics older than today into persistent usage records.
+func ProcessDailyStats() {
+	if Stats == nil {
+		return
+	}
+
+	today := time.Now().UTC().Format("2006-01-02")
+
+	Stats.Mu.Lock()
+	defer Stats.Mu.Unlock()
+
+	for dateStr, domains := range Stats.Data {
+		if dateStr >= today {
+			continue
+		}
+
+		date, err := time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			log.Log(log.Error, "invalid date key %s", dateStr)
+			continue
+		}
+
+		for domain, ds := range domains {
+			for classC, hits := range ds.ClientStats.ClassCs {
+				ipGuess := classC + ".1"
+				rec := mysql.UsageRecord{
+					Date:    date,
+					Domain:  domain,
+					ASN:     max.GetASN(ipGuess),
+					Subnet:  max.GetSubnet(ipGuess),
+					Country: max.GetCountryCode(ipGuess),
+					Hits:    hits,
+				}
+				if err := mysql.InsertOrUpdateUsage(rec); err != nil {
+					log.Log(log.Error, "usage insert error: %v", err)
+				}
+			}
+		}
+
+		delete(Stats.Data, dateStr)
+	}
 }

--- a/src/common/maxmind/geoip.go
+++ b/src/common/maxmind/geoip.go
@@ -181,6 +181,54 @@ func GetClassC(ipStr string) string {
 	return fmt.Sprintf("%d.%d.%d", ipv4[0], ipv4[1], ipv4[2])
 }
 
+// GetASN looks up the ASN for the provided IP address using the ASN database.
+func GetASN(ipStr string) string {
+	if maxmindAsn == nil {
+		log.Log(log.Error, "ASN DB is not loaded")
+		return ""
+	}
+
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		log.Log(log.Error, "Invalid IP address: %s", ipStr)
+		return ""
+	}
+
+	var record struct {
+		ASN uint `maxminddb:"autonomous_system_number"`
+	}
+
+	if err := maxmindAsn.Lookup(ip, &record); err != nil {
+		log.Log(log.Error, "ASN lookup error for %s: %v", ipStr, err)
+		return ""
+	}
+
+	if record.ASN == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("AS%d", record.ASN)
+}
+
+// GetSubnet derives the /24 (IPv4) or /56 (IPv6) subnet for the provided IP.
+func GetSubnet(ipStr string) string {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		log.Log(log.Error, "Invalid IP address: %s", ipStr)
+		return ""
+	}
+
+	if ipv4 := ip.To4(); ipv4 != nil {
+		mask := net.CIDRMask(24, 32)
+		subnet := ipv4.Mask(mask)
+		return fmt.Sprintf("%s/24", net.IP(subnet).String())
+	}
+
+	mask := net.CIDRMask(56, 128)
+	subnet := ip.Mask(mask)
+	return fmt.Sprintf("%s/56", subnet.String())
+}
+
 // Close frees resources used by maxmind. (If needed)
 func Close() {
 	if maxmindCity != nil {


### PR DESCRIPTION
## Summary
- provide helpers to look up ASN and IP subnets
- store aggregated request data in a `daily_usage` table
- periodically migrate in-memory stats to persistent records
- schedule daily stats processing on startup

## Testing
- `go vet ./...` *(fails: proxyconnect tcp: dial tcp 172.26.0.3:8080: connect: no route to host)*
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.26.0.3:8080: connect: no route to host)*
