### PR TITLE
Implement event retrieval and API endpoint

### DIFF
--- a/src/common/data/events.go
+++ b/src/common/data/events.go
@@ -79,3 +79,57 @@ func RecordEvent(checkType, checkName, memberName, domainName, endpoint string, 
 		}
 	}
 }
+
+// GetDowntimeEvents returns events for a member within the given time range.
+func GetDowntimeEvents(memberName string, start, end time.Time) ([]mysql.EventRecord, error) {
+	return mysql.GetEvents(memberName, start, end)
+}
+
+// GetMemberEvents retrieves events for a member and optional domain within a time range.
+func GetMemberEvents(memberName, domain string, start, end time.Time) ([]EventRecord, error) {
+	rows, err := mysql.FetchEvents(memberName, domain, start, end)
+	if err != nil {
+		return nil, err
+	}
+
+	events := make([]EventRecord, 0, len(rows))
+	for _, r := range rows {
+		var dataMap map[string]interface{}
+		if r.AdditionalData.Valid && r.AdditionalData.String != "" {
+			_ = json.Unmarshal([]byte(r.AdditionalData.String), &dataMap)
+		}
+
+		var domainName, endpoint, errText string
+		if r.DomainName.Valid {
+			domainName = r.DomainName.String
+		}
+		if r.Endpoint.Valid {
+			endpoint = r.Endpoint.String
+		}
+		if r.ErrorText.Valid {
+			errText = r.ErrorText.String
+		}
+
+		var endTime time.Time
+		if r.EndTime.Valid {
+			endTime = r.EndTime.Time
+		}
+
+		events = append(events, EventRecord{
+			CheckType:  r.CheckType,
+			CheckName:  r.CheckName,
+			MemberName: r.MemberName,
+			DomainName: domainName,
+			Endpoint:   endpoint,
+			Status:     r.Status,
+			ErrorText:  errText,
+			Data:       dataMap,
+			StartTime:  r.StartTime,
+			EndTime:    endTime,
+			StartDate:  r.StartTime.Format("2006-01-02"),
+			EndDate:    endTime.Format("2006-01-02"),
+		})
+	}
+
+	return events, nil
+}

--- a/src/common/data/mysql/events.go
+++ b/src/common/data/mysql/events.go
@@ -85,3 +85,66 @@ func FindOpenOfflineEvent(memberName, checkType, checkName, domainName, endpoint
 	}
 	return &event, nil
 }
+
+// GetEvents retrieves events for a member within the specified time range.
+func GetEvents(memberName string, start, end time.Time) ([]EventRecord, error) {
+	query := `
+               SELECT id, member_name, check_type, check_name, domain_name, endpoint, status, start_time, end_time, error_text, additional_data
+               FROM member_events
+               WHERE member_name = ? AND start_time >= ? AND start_time <= ?
+       `
+	rows, err := DB.Query(query, memberName, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query events: %w", err)
+	}
+	defer rows.Close()
+
+	var res []EventRecord
+	for rows.Next() {
+		var ev EventRecord
+		if err := rows.Scan(&ev.ID, &ev.MemberName, &ev.CheckType, &ev.CheckName, &ev.DomainName, &ev.Endpoint,
+			&ev.Status, &ev.StartTime, &ev.EndTime, &ev.ErrorText, &ev.AdditionalData); err != nil {
+			return nil, fmt.Errorf("scan error: %w", err)
+		}
+		res = append(res, ev)
+	}
+	return res, nil
+}
+
+// FetchEvents returns all events for the given member and domain within the specified time range.
+func FetchEvents(memberName, domainName string, start, end time.Time) ([]EventRecord, error) {
+	args := []interface{}{memberName, start, end}
+	query := `
+               SELECT id, member_name, check_type, check_name, domain_name, endpoint, status, start_time, end_time, error_text, additional_data FROM member_events
+               WHERE member_name = ? AND start_time >= ? AND start_time <= ?`
+
+	if domainName != "" {
+		query += " AND domain_name = ?"
+		args = append(args, domainName)
+	}
+
+	query += " ORDER BY start_time"
+
+	rows, err := DB.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch events: %w", err)
+	}
+	defer rows.Close()
+
+	events := []EventRecord{}
+	for rows.Next() {
+		var e EventRecord
+		err = rows.Scan(&e.ID, &e.MemberName, &e.CheckType, &e.CheckName, &e.DomainName, &e.Endpoint,
+			&e.Status, &e.StartTime, &e.EndTime, &e.ErrorText, &e.AdditionalData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan event row: %w", err)
+		}
+		events = append(events, e)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("row iteration error: %w", err)
+	}
+
+	return events, nil
+}

--- a/src/dnsApi/api/api_router.go
+++ b/src/dnsApi/api/api_router.go
@@ -30,6 +30,8 @@ func dnsApiRouter(w http.ResponseWriter, r *http.Request) {
 		res = handle_GetAllDomains(req)
 	case "getDomainKeys":
 		res = handle_GetDomainKeys(req)
+	case "getMemberEvents":
+		res = handle_GetMemberEvents(req)
 	default:
 		writeDnsResponse(w, Response{Result: "Invalid Request"})
 		return

--- a/src/dnsApi/api/handler_GetMemberEvents.go
+++ b/src/dnsApi/api/handler_GetMemberEvents.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	dat "ibp-geodns/src/common/data"
+	"time"
+)
+
+// handle_GetMemberEvents returns downtime events for a member within a time range.
+func handle_GetMemberEvents(req Request) Response {
+	start, err := time.Parse(time.RFC3339, req.Parameters.StartTime)
+	if err != nil {
+		return Response{Result: "invalid startTime"}
+	}
+	end, err := time.Parse(time.RFC3339, req.Parameters.EndTime)
+	if err != nil {
+		return Response{Result: "invalid endTime"}
+	}
+
+	events, err := dat.GetMemberEvents(req.Parameters.MemberName, req.Parameters.Domain, start, end)
+	if err != nil {
+		return Response{Result: err.Error()}
+	}
+
+	return Response{Result: events}
+}

--- a/src/dnsApi/api/types.go
+++ b/src/dnsApi/api/types.go
@@ -63,6 +63,12 @@ type Parameters struct {
 		Published bool   `json:"published"`
 		Content   string `json:"content"`
 	} `json:"key"`
+
+	// Additional fields for event queries
+	MemberName string `json:"memberName"`
+	Domain     string `json:"domain"`
+	StartTime  string `json:"startTime"`
+	EndTime    string `json:"endTime"`
 }
 
 // DomainInfo provides information about a domain.


### PR DESCRIPTION
## Summary
- add `GetMemberEvents` and retain `GetDowntimeEvents`
- support both `GetEvents` and `FetchEvents` in MySQL layer
- expose downtime queries with a DNS API handler and router case
- expand request parameters for member event queries

## Testing
- `go vet ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*
