### PR TITLE
Fix Matrix event handler signature

### DIFF
--- a/src/mgmtBotMatrix/mgmtBotMatrix.go
+++ b/src/mgmtBotMatrix/mgmtBotMatrix.go
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	syncer := bot.Client.Syncer.(*mautrix.DefaultSyncer)
-	syncer.OnEventType(event.EventMessage, func(ev *event.Event) {
+	syncer.OnEventType(event.EventMessage, func(_ mautrix.EventSource, ev *event.Event) {
 		if ev.RoomID != bot.RoomID {
 			return
 		}


### PR DESCRIPTION
## Summary
- fix parameter list for Matrix message handler
- ignore unused first argument

## Testing
- `gofmt -w src/mgmtBotMatrix/mgmtBotMatrix.go`
- `go vet ./...` *(fails: missing go.sum entries)*